### PR TITLE
Use schema when given in the request body

### DIFF
--- a/packages/data-api-local/README.md
+++ b/packages/data-api-local/README.md
@@ -48,7 +48,11 @@ const result = await client.executeStatement({
       longValue: 42
     }
   }],
-  database: 'example'
+  database: 'example',
+  // `schema` is an optional parameter for `BeginTransaction`, `ExecuteSql` and `ExecuteStatement` operations
+  // although reportedly "not supported" for `ExecuteStatement`. See AWS docs for most up to date supported status.
+  // https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html
+  schema: 'public',
   // secretArn and resourceArn are not used but are required for the AWS SDK
   secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy',
   resourceArn: 'arn:aws:rds:us-east-1:123456789012:cluster:dummy'

--- a/packages/data-api-local/src/Client.ts
+++ b/packages/data-api-local/src/Client.ts
@@ -2,16 +2,19 @@ import * as RDSDataService from 'aws-sdk/clients/rdsdataservice'
 
 export interface ExecuteSqlRequest {
   sqlStatements: RDSDataService.Types.SqlStatement;
+  schema?: string;
 }
 
 export interface ExecuteStatementRequest {
   sql: RDSDataService.Types.SqlStatement;
+  schema?: string;
   parameters?: RDSDataService.Types.SqlParametersList;
   includeResultMetadata?: boolean;
 }
 
 export interface BatchExecuteStatementRequest {
   sql: RDSDataService.Types.SqlStatement;
+  schema?: string;
   parameterSets?: RDSDataService.Types.SqlParameterSets;
 }
 
@@ -20,7 +23,7 @@ export abstract class Client {
 
   abstract async disconnect (): Promise<void>
 
-  abstract async beginTransaction (): Promise<void>
+  abstract async beginTransaction (schema?: string): Promise<void>
 
   abstract async commitTransaction (): Promise<void>
 

--- a/packages/data-api-local/src/Server.ts
+++ b/packages/data-api-local/src/Server.ts
@@ -149,8 +149,11 @@ export class Server {
     res: express.Response,
     next: express.NextFunction
   ): Promise<void> {
+    // Intentionally omit `schema` from `client.executeStatement` call as it's "not currently supported" according to AWS docs.
+    // See AWS docs for most up to date supported status. https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteStatement.html
     const {
       database,
+      schema,
       transactionId,
       sql,
       ...rest

--- a/packages/data-api-local/src/utils/transformResult.test.ts
+++ b/packages/data-api-local/src/utils/transformResult.test.ts
@@ -1,4 +1,4 @@
-import { transformResult } from './transformResult'
+import { transformStatementResult } from './transformResult'
 import { QueryResult, types } from 'pg'
 
 test('transformResult', () => {
@@ -155,7 +155,7 @@ test('transformResult', () => {
       format: 'TEXT'
     }]
   }
-  const result = transformResult(queryResult)
+  const result = transformStatementResult(queryResult)
   expect(result).toMatchObject([[
     { isNull: true },
     { stringValue: 'example' },

--- a/packages/data-api-local/src/utils/transformResult.ts
+++ b/packages/data-api-local/src/utils/transformResult.ts
@@ -1,5 +1,5 @@
 import * as RDSDataService from 'aws-sdk/clients/rdsdataservice'
-import { QueryResult, types, FieldDef } from 'pg'
+import { QueryResult, types, FieldDef, QueryArrayResult } from 'pg'
 import { TypeId } from 'pg-types'
 
 const transformStringValue = (value: unknown): string => {
@@ -73,7 +73,19 @@ const transformValue = (field: FieldDef, value: unknown): RDSDataService.Types.F
   }
 }
 
-export const transformResult = (result: QueryResult): RDSDataService.Types.SqlRecords => {
+export const transformSqlResult = (result: QueryArrayResult): RDSDataService.Records => {
+  return result.rows.map((row): RDSDataService.Record => {
+    return {
+      values: row.map((value, index): RDSDataService.Value => {
+        const field = result.fields[index];
+
+        return transformValue(field, value);
+      }),
+    };
+  });
+};
+
+export const transformStatementResult = (result: QueryArrayResult): RDSDataService.Types.SqlRecords => {
   return result.rows.map((columns) => {
     return columns.map((value: unknown, index: number) => {
       const field = result.fields[index]


### PR DESCRIPTION
Adds the ability to specify schema in the request body to emulate the AWS data API more closely.
Defaults to `public` (postgres default) if not specified.
Implements `executeSql` response as per [AWS docs](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_ExecuteSql.html#API_ExecuteSql_ResponseSyntax).