### PR TITLE
migrations table id type not compatible with mysql-aurora

### DIFF
--- a/packages/data-api-migrations/src/DataAPIMigrations.ts
+++ b/packages/data-api-migrations/src/DataAPIMigrations.ts
@@ -130,7 +130,7 @@ export class DataAPIMigrations {
 
   private async ensureMigrationTable (): Promise<void> {
     await this.dataAPI.query(
-      'CREATE TABLE IF NOT EXISTS __migrations__ (id varchar NOT NULL UNIQUE)',
+      'CREATE TABLE IF NOT EXISTS __migrations__ (id varchar(255) NOT NULL UNIQUE)',
       undefined,
       { includeResultMetadata: false }
     )

--- a/packages/data-api-migrations/src/index.test.ts
+++ b/packages/data-api-migrations/src/index.test.ts
@@ -67,7 +67,7 @@ describe('DataAPIMigrations#getAppliedMigrationIds', () => {
   it('ensures the migration table exists', async () => {
     await manager.getAppliedMigrationIds()
     expect(auroraDataAPIMock.query).toHaveBeenCalledWith(
-      'CREATE TABLE IF NOT EXISTS __migrations__ (id varchar NOT NULL UNIQUE)',
+      'CREATE TABLE IF NOT EXISTS __migrations__ (id varchar(255) NOT NULL UNIQUE)',
       undefined,
       { includeResultMetadata: false }
     )


### PR DESCRIPTION
I have trouble starting the migrations project. When I try to execute my first migration it throws the following error:

BadRequestException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NOT NULL UNIQUE)' at line 1

version: 5.7.mysql_aurora.2.04.8

PS: unit tests pass locally. Any idea why is this one failing?