### PR TITLE
Bump versions of all packages to v1.0.0-alpha.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,5 +6,5 @@
     "packages/data-api-migrations",
     "packages/data-api-migrations-serverless"
   ],
-  "version": "1.0.0-alpha.3"
+  "version": "1.0.0-alpha.4"
 }

--- a/packages/aurora-data-api/package-lock.json
+++ b/packages/aurora-data-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurora-data-api",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/aurora-data-api/package.json
+++ b/packages/aurora-data-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurora-data-api",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Aurora Serverless Data API Client that simplifies the request and response payloads.",
   "homepage": "https://github.com/marcgreenstock/data-api-suite/tree/master/packages/aurora-data-api",
   "repository": {

--- a/packages/data-api-local-serverless/package-lock.json
+++ b/packages/data-api-local-serverless/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-local-serverless",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-api-local-serverless/package.json
+++ b/packages/data-api-local-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-local-serverless",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.4",
   "description": "Serverless plugin to start an Aurora Serverless Data API emulator for local development.",
   "homepage": "https://github.com/marcgreenstock/data-api-suite/tree/master/packages/data-api-local-serverless",
   "repository": {
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "chalk": "^3.0.0",
-    "data-api-local": "^1.0.0-alpha.2"
+    "data-api-local": "1.0.0-alpha.4"
   },
   "peerDependencies": {
     "serverless-offline": "^5.x"

--- a/packages/data-api-local-serverless/package.json
+++ b/packages/data-api-local-serverless/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "chalk": "^3.0.0",
-    "data-api-local": "1.0.0-alpha.4"
+    "data-api-local": "^1.0.0-alpha.4"
   },
   "peerDependencies": {
     "serverless-offline": "^5.x"

--- a/packages/data-api-local/package-lock.json
+++ b/packages/data-api-local/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-local",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-api-local/package.json
+++ b/packages/data-api-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-local",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.4",
   "description": "AWS Aurora Serverless Data API emulator for local development.",
   "homepage": "https://github.com/marcgreenstock/data-api-suite/tree/master/packages/data-api-local",
   "repository": {

--- a/packages/data-api-migrations-serverless/package-lock.json
+++ b/packages/data-api-migrations-serverless/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-migrations-serverless",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-api-migrations-serverless/package.json
+++ b/packages/data-api-migrations-serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-migrations-serverless",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Serverless plugin to start an Aurora Serverless Data API emulator for local development.",
   "homepage": "https://github.com/marcgreenstock/data-api-suite/tree/master/packages/data-api-migrations-serverless",
   "repository": {
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^3.0.0",
-    "data-api-migrations": "^1.0.0-alpha.3"
+    "data-api-migrations": "1.0.0-alpha.4"
   },
   "devDependencies": {
     "@types/jest": "^24.9.1",

--- a/packages/data-api-migrations-serverless/package.json
+++ b/packages/data-api-migrations-serverless/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^3.0.0",
-    "data-api-migrations": "1.0.0-alpha.4"
+    "data-api-migrations": "^1.0.0-alpha.4"
   },
   "devDependencies": {
     "@types/jest": "^24.9.1",

--- a/packages/data-api-migrations/package-lock.json
+++ b/packages/data-api-migrations/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-migrations",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-api-migrations/package.json
+++ b/packages/data-api-migrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-api-migrations",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Migrations library for Aurora Serverless Data API.",
   "homepage": "https://github.com/marcgreenstock/data-api-suite/tree/master/packages/data-api-migrations",
   "repository": {
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "aurora-data-api": "^1.0.0-alpha.3",
+    "aurora-data-api": "1.0.0-alpha.4",
     "date-fns": "^2.11.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",

--- a/packages/data-api-migrations/package.json
+++ b/packages/data-api-migrations/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "aurora-data-api": "1.0.0-alpha.4",
+    "aurora-data-api": "^1.0.0-alpha.4",
     "date-fns": "^2.11.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Version `v1.0.0-alpha.4` of `data-api-local` has been published to [npm](https://www.npmjs.com/package/data-api-local) already (as that is all I have permission to publish). This is essentially useless however without releasing a new version of `data-api-local-serverless` which depends on the exact version of `data-api-local` at `v1.0.0-alpha.2`.

This PR proposes that we change the version of all packages to the tagged version in this repo (`v.1.0.0-alpha.4`). This will ensure that the tags in the git repo match the tags in the package.json file of each package.

Additionally, these packages should be published soon after as:
- they contain changes currently in master (such as using compatible-versioned dependencies instead of exact) that pass tests but not yet published. They also work well in at least one significant project I know of.
- `v1.0.0-alpha.4` of `data-api-local` can be used from `data-api-local-serverless`.
